### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,16 +16,30 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
-    name: "Run linters"
+  lint-rust:
+    name: "Run Rust linter"
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Enable Rust cache
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings
+          
+  lint-bash:
+    name: "Run bash linter"
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Run linters
-        run: make lint
+      - uses: actions/checkout@v3
+      
+      - name: Run shellcheck
+        run: shellcheck install.sh
 
   build-pam-module:
     name: "Build PAM module"
@@ -33,17 +47,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-
+      - uses: actions/checkout@v3
+          
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install libpam
         run: sudo apt-get install libpam0g-dev
@@ -51,7 +58,7 @@ jobs:
       - name: Build
         run: make clean build/pam_wsl_hello.so
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload artifact
         with:
           name: "PAM module"
@@ -64,12 +71,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+      
+      - name: Enable Rust cache
+        uses: Swatinem/rust-cache@v2
+        
       - name: Build
         run: make clean build/WindowsHelloBridge.exe
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload artifacts
         with:
           name: "Windows Binary"
@@ -84,14 +94,14 @@ jobs:
     needs: [build-pam-module, build-windows-binary]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "Windows Binary"
           path: build
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: "PAM module"
           path: build
@@ -115,9 +125,9 @@ jobs:
           release_name: release
         run: |
           make -d release RELEASE="$release_name"
-          echo "::set-output name=release_asset::$release_name.tar.gz"
+          echo "release_asset=$release_name.tar.gz" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ github.event.inputs.should_publish != 'yes' }}
         name: Upload the release asset (CI)
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RELEASE := release
 
 WIN_CARGO="cargo.exe"
 
-.PHONY: all clean cleanall cleanrelease install release lint
+.PHONY: all clean cleanall cleanrelease install release
 
 all: build/pam_wsl_hello.so build/WindowsHelloBridge.exe
 
@@ -39,7 +39,3 @@ release: all
 	cp -R build $(RELEASE)/
 	cp install.sh pam-config $(RELEASE)/
 	tar cvzf $(RELEASE).tar.gz $(RELEASE)
-
-lint:
-	shellcheck install.sh
-	cargo clippy -- -D warnings

--- a/win_hello_bridge/Cargo.toml
+++ b/win_hello_bridge/Cargo.toml
@@ -11,4 +11,4 @@ name = "WindowsHelloBridge"
 path = "src/main.rs"
 
 [dependencies]
-windows = { version = "0.27", features = ["alloc", "Foundation", "Security_Credentials", "Security_Cryptography", "Storage_Streams", "UI_Popups", "Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.32", features = ["alloc", "Foundation", "Security_Credentials", "Security_Cryptography", "Storage_Streams", "UI_Popups", "Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/win_hello_bridge/src/authenticator.rs
+++ b/win_hello_bridge/src/authenticator.rs
@@ -2,7 +2,6 @@ use crate::FailureReason;
 use std::sync::mpsc;
 use std::time::Duration;
 use windows::{
-    core::Handle,
     Security::{Credentials::KeyCredentialManager, Cryptography::CryptographicBuffer},
     Win32::{
         Foundation::PWSTR,

--- a/win_hello_bridge/src/main.rs
+++ b/win_hello_bridge/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
                 let pem_key = creator::create_public_key(key_name)?;
                 let file_name = format!("./{}.pem", key_name);
                 println!("file name: {}", file_name);
-                std::fs::write(&file_name, &pem_key).unwrap();
+                std::fs::write(&file_name, pem_key).unwrap();
                 println!(
                     "Done. The public credential key is written in '{}'",
                     file_name

--- a/wsl_hello_pam/Cargo.toml
+++ b/wsl_hello_pam/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 libc = "0.2.0"
-openssl = { version = "0.10.29", features = ["vendored"] }
+openssl = { version = "0.10.48", features = ["vendored"] }
 toml = "0.4"
 uuid = { version = "0.5", features = ["v4"] }

--- a/wsl_hello_pam/src/auth.rs
+++ b/wsl_hello_pam/src/auth.rs
@@ -216,7 +216,7 @@ fn authenticate_via_hello(pamh: *mut pam_handle_t) -> Result<i32, HelloAuthentic
         let challenge_tmpfile_in = Stdio::from(challenge_tmpfile);
 
         let authenticator_path = get_authenticator_path()?;
-        let authenticator = Command::new(&authenticator_path)
+        let authenticator = Command::new(authenticator_path)
             .arg("authenticator")
             .arg(credential_key_name)
             .current_dir(Path::new(&get_win_mnt()?))


### PR DESCRIPTION
The Rust linter had to be moved to cicd.yaml because the new windows-rs v0.32 would not lint in ubuntu.
